### PR TITLE
feat: auto-version via CI using InformationalVersion + run number

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-sea-0dfd8ff10.yml
+++ b/.github/workflows/azure-static-web-apps-brave-sea-0dfd8ff10.yml
@@ -25,8 +25,14 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Set build version
+        run: |
+          APP_VERSION="${GITHUB_RUN_NUMBER}-${GITHUB_SHA::8}"
+          printf '{"version":"%s","releasedAt":"%s"}\n' "$APP_VERSION" "$(date -u +%Y-%m-%d)" > Client/wwwroot/version.json
+          echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
+
       - name: Publish Blazor Client
-        run: dotnet publish ./Client/Client.csproj --configuration Release --output ./release --nologo
+        run: dotnet publish ./Client/Client.csproj --configuration Release --output ./release --nologo -p:InformationalVersion=$APP_VERSION
 
       - name: Build And Deploy
         id: builddeploy

--- a/Client/Services/VersionCheckService.cs
+++ b/Client/Services/VersionCheckService.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 
 namespace BlazorApp.Client.Services
@@ -11,8 +12,11 @@ namespace BlazorApp.Client.Services
 
     public class VersionCheckService : IVersionCheckService
     {
-        // Bump this constant with every deployment; must match wwwroot/version.json
-        public const string AppVersion = "2.0.0";
+        public static readonly string AppVersion =
+            typeof(VersionCheckService).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                ?.InformationalVersion
+            ?? "dev";
 
         private readonly HttpClient _httpClient;
         private string? _serverVersion;

--- a/Client/staticwebapp.config.json
+++ b/Client/staticwebapp.config.json
@@ -6,6 +6,12 @@
         {
             "route": "/api/*",
             "allowedRoles": ["anonymous"]
+        },
+        {
+            "route": "/version.json",
+            "headers": {
+                "Cache-Control": "no-store"
+            }
         }
     ]
 }

--- a/Client/wwwroot/version.json
+++ b/Client/wwwroot/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.0.0",
-  "releasedAt": "2026-05-21"
+  "version": "dev",
+  "releasedAt": "dev"
 }


### PR DESCRIPTION
- CI workflow: compute APP_VERSION from GITHUB_RUN_NUMBER + GITHUB_SHA and write version.json before dotnet publish; pass -p:InformationalVersion so the same version is embedded in the compiled WASM assembly
- VersionCheckService: replace hardcoded AppVersion const with static readonly that reads AssemblyInformationalVersionAttribute at runtime (fallback: 'dev')
- staticwebapp.config.json: add Cache-Control: no-store for /version.json
- version.json: reset to 'dev' placeholder so local dev has no spurious modal