### PR TITLE
fix: prevent infinite reload loop on update modal

### DIFF
--- a/Client/staticwebapp.config.json
+++ b/Client/staticwebapp.config.json
@@ -4,14 +4,32 @@
     },
     "routes": [
         {
-            "route": "/api/*",
-            "allowedRoles": ["anonymous"]
+            "route": "/index.html",
+            "headers": {
+                "Cache-Control": "no-cache"
+            }
+        },
+        {
+            "route": "/_framework/blazor.webassembly.js",
+            "headers": {
+                "Cache-Control": "no-cache"
+            }
+        },
+        {
+            "route": "/_framework/blazor.boot.json",
+            "headers": {
+                "Cache-Control": "no-cache"
+            }
         },
         {
             "route": "/version.json",
             "headers": {
                 "Cache-Control": "no-store"
             }
+        },
+        {
+            "route": "/api/*",
+            "allowedRoles": ["anonymous"]
         }
     ]
 }

--- a/Client/wwwroot/index.html
+++ b/Client/wwwroot/index.html
@@ -166,7 +166,7 @@
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
     <script>
         window.hardReload = () => {
-            window.location.reload(true);
+            window.location.replace('/?_cb=' + Date.now());
         };
 
         window.fireConfetti = () => {


### PR DESCRIPTION
- hardReload: replace reload(true) [deprecated, ignored by modern browsers] with location.replace('/?_cb='+Date.now()) which forces a true cache-busted navigation, ensuring the browser fetches fresh Blazor bootstrap files
- staticwebapp.config.json: add Cache-Control: no-cache for index.html, blazor.webassembly.js, and blazor.boot.json so non-fingerprinted Blazor entry files are always revalidated on load