### PR TITLE
Optimize modal display logic in UpdateModal.razor

### DIFF
--- a/Client/Components/UpdateModal.razor
+++ b/Client/Components/UpdateModal.razor
@@ -8,6 +8,9 @@
     public async Task ShowIfNeededAsync(string serverVersion)
     {
         _serverVersion = serverVersion;
+        var loadedVersion = await LocalStorage.GetItemAsync<string>("emea_loaded_version");
+        if (loadedVersion == serverVersion) return;
+
         var dismissedVersion = await LocalStorage.GetItemAsync<string>("updateDismissedVersion");
         if (dismissedVersion == serverVersion) return;
 


### PR DESCRIPTION
Added a check to prevent the modal from being displayed if the `serverVersion` matches the `loadedVersion` stored in local storage. Introduced a call to retrieve `loadedVersion` from local storage and updated the flow to ensure the modal is only shown when `serverVersion` differs from both `loadedVersion` and `dismissedVersion`.