### PR TITLE
feat: assdex progress fix, score commas, leaderboard frenzy stats, bi…

### DIFF
--- a/Client/Components/LeaderboardStatsModal.razor
+++ b/Client/Components/LeaderboardStatsModal.razor
@@ -57,6 +57,8 @@
                         <div class="lb-col-name">Player</div>
                         <div class="lb-col-score">Score</div>
                         <div class="lb-col-cps">CPS</div>
+                        <div class="lb-col-frenzies">Frnzy</div>
+                        <div class="lb-col-chain">Chain</div>
                         <div class="lb-col-date">Date</div>
                     </div>
 
@@ -72,8 +74,10 @@
                                 else                { <span class="lb-rank-num">@rank</span> }
                             </div>
                             <div class="lb-col-name lb-player-name">@entry.PlayerName</div>
-                            <div class="lb-col-score lb-val-score">@((int)Math.Truncate(entry.Score))</div>
+                            <div class="lb-col-score lb-val-score">@(((int)Math.Truncate(entry.Score)).ToString("N0"))</div>
                             <div class="lb-col-cps lb-val-cps">@entry.CPS</div>
+                            <div class="lb-col-frenzies lb-val-frenzies">@(entry.FrenzyCount.HasValue ? entry.FrenzyCount.Value.ToString() : "-")</div>
+                            <div class="lb-col-chain lb-val-chain">@(entry.PeakFrenzyChain.HasValue ? entry.PeakFrenzyChain.Value.ToString() : "-")</div>
                             <div class="lb-col-date lb-val-date">
                                 @entry.GameDate.ToString("MMM d")
                                 <span class="lb-time">@entry.GameDate.ToString("HH:mm")</span>

--- a/Client/Components/LeaderboardStatsModal.razor.css
+++ b/Client/Components/LeaderboardStatsModal.razor.css
@@ -112,6 +112,8 @@
 .lb-header-row .lb-col-name,
 .lb-header-row .lb-col-score,
 .lb-header-row .lb-col-cps,
+.lb-header-row .lb-col-frenzies,
+.lb-header-row .lb-col-chain,
 .lb-header-row .lb-col-date {
     font-size: 0.7rem;
     font-weight: 700;
@@ -142,12 +144,24 @@
 }
 
 .lb-col-score {
-    width: 56px;
+    width: 72px;
     flex-shrink: 0;
     text-align: right;
 }
 
 .lb-col-cps {
+    width: 48px;
+    flex-shrink: 0;
+    text-align: right;
+}
+
+.lb-col-frenzies {
+    width: 48px;
+    flex-shrink: 0;
+    text-align: right;
+}
+
+.lb-col-chain {
     width: 48px;
     flex-shrink: 0;
     text-align: right;
@@ -188,6 +202,18 @@
     font-size: 0.85rem;
     font-weight: 600;
     color: #fbbf24;
+}
+
+.lb-val-frenzies {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #fb923c;
+}
+
+.lb-val-chain {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #a78bfa;
 }
 
 .lb-val-date {
@@ -239,8 +265,10 @@
 @media (max-width: 480px) {
     .lb-tab { padding: 10px 12px; font-size: 0.8rem; gap: 4px; }
     .lb-col-cps { display: none; }
+    .lb-col-frenzies { display: none; }
+    .lb-col-chain { display: none; }
     .lb-col-date { width: 56px; }
-    .lb-col-score { width: 50px; }
+    .lb-col-score { width: 56px; }
     .lb-player-name { font-size: 0.85rem; }
     .lb-val-score { font-size: 0.88rem; }
 }

--- a/Client/Components/SaveScoreModal.razor.cs
+++ b/Client/Components/SaveScoreModal.razor.cs
@@ -25,6 +25,8 @@ namespace BlazorApp.Client.Components
         private string errorMessage = string.Empty;
         private bool isHighScore = false;
         private int playerRank = 0;
+        private int _frenzyCount = 0;
+        private int _peakFrenzyChain = 0;
 
         // Name claiming state
         private enum NameState { Unknown, Checking, Free, ClaimedOwned, ClaimedNotOwned }
@@ -37,11 +39,13 @@ namespace BlazorApp.Client.Components
         private bool _showClaimForm = false;
         private bool _showPasswordField = false;
 
-        public async Task Show(double score, int totalClicks, Dictionary<AssTypeEnum, int> breakdown)
+        public async Task Show(double score, int totalClicks, Dictionary<AssTypeEnum, int> breakdown, int frenzyCount = 0, int peakFrenzyChain = 0)
         {
             Score = score;
             TotalClicks = totalClicks;
             AssBreakdown = breakdown;
+            _frenzyCount = frenzyCount;
+            _peakFrenzyChain = peakFrenzyChain;
             errorMessage = string.Empty;
             isSaving = false;
             password = string.Empty;
@@ -237,7 +241,9 @@ namespace BlazorApp.Client.Components
                     TotalClicks = TotalClicks,
                     GameDate = DateTime.UtcNow,
                     AssTypeBreakdown = AssBreakdown.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value),
-                    GameDurationSeconds = 60
+                    GameDurationSeconds = 60,
+                    FrenzyCount = _frenzyCount,
+                    PeakFrenzyChain = _peakFrenzyChain
                 };
 
                 await SharedLeaderboardService.SaveScoreAsync(entry, authToken);
@@ -266,7 +272,9 @@ namespace BlazorApp.Client.Components
                         TotalClicks = TotalClicks,
                         GameDate = DateTime.UtcNow,
                         AssTypeBreakdown = AssBreakdown.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value),
-                        GameDurationSeconds = 60
+                        GameDurationSeconds = 60,
+                        FrenzyCount = _frenzyCount,
+                        PeakFrenzyChain = _peakFrenzyChain
                     };
                     await LocalLeaderboardService.SaveScoreAsync(entry);
                     errorMessage += " Score saved locally as backup.";

--- a/Client/Pages/Home.razor
+++ b/Client/Pages/Home.razor
@@ -57,7 +57,7 @@
         {
             <div class="challenge-banner" @onclick:stopPropagation="true">
                 <i class="bi bi-trophy-fill challenge-banner-icon"></i>
-                <span>Beat <strong>@_challengerName</strong>'s score of <strong>@((int)_challengeScore)</strong>!</span>
+                <span>Beat <strong>@_challengerName</strong>'s score of <strong>@(((int)_challengeScore).ToString("N0"))</strong>!</span>
                 <button class="challenge-banner-dismiss" @onclick="() => _showChallengeBanner = false" title="Dismiss">
                     <i class="bi bi-x"></i>
                 </button>
@@ -97,7 +97,7 @@
                 @(string.IsNullOrWhiteSpace(_currentPlayerName) ? "Set Your Name" : _currentPlayerName)
             </span>
             <span class="game-player-card-pb" style="@(_personalBestScore.HasValue ? "" : "display:none")">
-                Personal Best: @((int)(_personalBestScore ?? 0))
+                Personal Best: @(((int)(_personalBestScore ?? 0)).ToString("N0"))
             </span>
         </button>
 
@@ -151,20 +151,20 @@
              @onclick:stopPropagation="true">
 
             <div class="go-score-block">
-                <div class="go-score-num">@((int)Math.Truncate(assesEaten))</div>
+                <div class="go-score-num">@(((int)Math.Truncate(assesEaten)).ToString("N0"))</div>
                 <div class="go-score-lbl">Asses Devoured</div>
                 <div class="go-pb-badge" style="@(_isPersonalBest ? "" : "display:none")">
                     <i class="bi bi-stars"></i> Personal Best!
                 </div>
                 <div class="go-prev-best" style="@(!_isPersonalBest && _personalBestScore.HasValue ? "" : "display:none")">
-                    Your best: @((int)(_personalBestScore ?? 0))
+                    Your best: @(((int)(_personalBestScore ?? 0)).ToString("N0"))
                 </div>
                 <div class="go-score-msg" style="@(string.IsNullOrEmpty(scoreText) ? "display:none" : "")">@scoreText</div>
                 <div class="go-challenge-win" style="@(_challengeScore > 0 && assesEaten > _challengeScore ? "" : "display:none")">
-                    <i class="bi bi-trophy-fill"></i> Beat @_challengerName's @((int)_challengeScore)!
+                    <i class="bi bi-trophy-fill"></i> Beat @_challengerName's @(((int)_challengeScore).ToString("N0"))!
                 </div>
                 <div class="go-challenge-miss" style="@(_challengeScore > 0 && assesEaten <= _challengeScore ? "" : "display:none")">
-                    <i class="bi bi-trophy"></i> @_challengerName challenged: beat @((int)_challengeScore)
+                    <i class="bi bi-trophy"></i> @_challengerName challenged: beat @(((int)_challengeScore).ToString("N0"))
                 </div>
             </div>
 

--- a/Client/Pages/Home.razor.cs
+++ b/Client/Pages/Home.razor.cs
@@ -101,8 +101,8 @@ namespace BlazorApp.Client.Pages
         protected override async Task OnInitializedAsync()
         {
             await base.OnInitializedAsync();
-            _progressCache = await ProgressService.LoadAsync(_currentPlayerName);
             _currentPlayerName = await SettingsService.GetLastPlayerNameAsync() ?? string.Empty;
+            _progressCache = await ProgressService.LoadAsync(_currentPlayerName);
             await LoadSettings();
             ParseChallengeFromUrl();
         }
@@ -452,7 +452,7 @@ namespace BlazorApp.Client.Pages
 
                 if (playSounds)
                 {
-                    await js.InvokeVoidAsync("playSound", sound, volume);
+                    await js.InvokeVoidAsync("playBiteSound", sound, volume);
                 }
             }
 
@@ -567,7 +567,9 @@ namespace BlazorApp.Client.Pages
                     TotalClicks = totalClicks,
                     GameDate = DateTime.UtcNow,
                     AssTypeBreakdown = Breakdown.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value),
-                    GameDurationSeconds = 60
+                    GameDurationSeconds = 60,
+                    FrenzyCount = frenzyCount,
+                    PeakFrenzyChain = _peakChainLevel
                 };
 
                 await LeaderboardService.SaveScoreAsync(entry, token);
@@ -580,7 +582,7 @@ namespace BlazorApp.Client.Pages
             {
                 Console.WriteLine($"[Home] Auto-save failed: {ex.Message}");
                 // Fall back to manual save modal
-                await InvokeAsync(async () => await SaveScoreDialog?.Show((double)assesEaten, totalClicks, Breakdown));
+                await InvokeAsync(async () => await SaveScoreDialog?.Show((double)assesEaten, totalClicks, Breakdown, frenzyCount, _peakChainLevel));
             }
             finally
             {

--- a/Client/wwwroot/index.html
+++ b/Client/wwwroot/index.html
@@ -192,9 +192,28 @@
         };
 
         window.playSound = (src, volume) => {
-            console.log(`playing sound ${src}`);
             var audio = new Audio(src);
-            audio.play();
+            audio.volume = volume ?? 1;
+            audio.play().catch(() => {});
+        }
+
+        // Bite sound: throttled + pooled to prevent audio pile-up at high CPS
+        const _biteAudioPool = {};
+        const _biteLastPlayed = {};
+        const BITE_COOLDOWN_MS = 80;
+
+        window.playBiteSound = (src, volume) => {
+            const now = Date.now();
+            if (_biteLastPlayed[src] && (now - _biteLastPlayed[src]) < BITE_COOLDOWN_MS) return;
+            _biteLastPlayed[src] = now;
+
+            if (!_biteAudioPool[src]) {
+                _biteAudioPool[src] = new Audio(src);
+            }
+            const audio = _biteAudioPool[src];
+            audio.volume = volume ?? 1;
+            audio.currentTime = 0;
+            audio.play().catch(() => {});
         }
 
         window.copyToClipboard = (text) => navigator.clipboard.writeText(text);

--- a/Shared/LeaderboardEntry.cs
+++ b/Shared/LeaderboardEntry.cs
@@ -11,6 +11,8 @@ namespace BlazorApp.Shared
         public DateTime GameDate { get; set; }
         public Dictionary<string, int> AssTypeBreakdown { get; set; } = new();
         public int GameDurationSeconds { get; set; } = 60;
+        public int? FrenzyCount { get; set; }
+        public int? PeakFrenzyChain { get; set; }
         public double ClickEfficiency => TotalClicks > 0 ? Math.Round(Score / TotalClicks, 3) : 0;
         public double CPS => GameDurationSeconds > 0 ? Math.Round((double)TotalClicks / GameDurationSeconds, 2) : 0;
     }


### PR DESCRIPTION
…te sound throttle

- Fix assdex progress loading: player name now fetched before progress load in OnInitializedAsync
- Add comma separators to all score displays (N0 format)
- Add FrenzyCount and PeakFrenzyChain (nullable int?) to LeaderboardEntry
- Pass frenzy data through AutoSave and SaveScoreModal paths
- Add FRNZY and CHAIN columns to leaderboard modal; old entries show '-'
- Widen score column for comma-formatted numbers; hide new cols on mobile
- Add playBiteSound() with 80ms throttle + audio pooling to prevent sound pile-up at high CPS
- Fix playSound() to actually apply volume parameter
- Use playBiteSound for bite sounds in EatPiece()